### PR TITLE
Allow users to specify additional packages to install

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -21,13 +21,17 @@ fi
 # Folder to load, chosen by user
 FOLDER=$(${FUZZY_FINDER} <<< ${FOLDERS_WITH_ZSHRC})
 
+# Addtiononal dependencies to install if dependencies file found
+[ -f "${0:a:h}/${FOLDER}/depedencies" ] && ADD_DEPENDENCIES=($(grep -v "#" ${0:a:h}/${FOLDER}/depedencies || true))
+
 # Create a Dockerfile
 DOCKERFILE="Dockerfile"
 cat > "${0:a:h}/${DOCKERFILE}" <<END
 FROM ubuntu:18.04
 RUN apt update && \
     apt install --yes ncurses-dev unzip zsh git subversion curl build-essential python \
-                        vim htop sudo golang-go cmake redis-server libhiredis-dev
+                        vim htop sudo golang-go cmake redis-server libhiredis-dev \
+                        ${ADD_DEPENDENCIES[@]:-}
 
 RUN adduser --disabled-password --gecos '' user
 RUN adduser user sudo


### PR DESCRIPTION
Future uploaders can optionally include a "dependencies" file along with their zshrc which specifies additional packages to be installed when the Docker container is set up. Packages can be listed line by line and commenting using '#' is supported. At the moment there is no detection as to whether or not the package actually exists in repo's and thus if a user lists a non-existent package the Docker container will fail to start.